### PR TITLE
Retina display bug fix

### DIFF
--- a/jquery.corner.js
+++ b/jquery.corner.js
@@ -132,7 +132,9 @@ $.fn.corner = function(options) {
                 $this.css(radius ? 'border-bottom-right-radius' : moz ? '-moz-border-radius-bottomright' : '-webkit-border-bottom-right-radius', width + 'px');
             return;
         }
-            
+        
+			$this.css('-webkit-background-clip', 'padding-box'); // fixes stray-line bug on retina displays
+
         strip = document.createElement('div');
         $(strip).css({
             overflow: 'hidden',


### PR DESCRIPTION
On retina displays, a stray vertical line appears for boxes that do not have all 4 corners rounded.
Setting: '-webkit-background-clip: padding-box' seems to fix the problem.
